### PR TITLE
RAfilter. Первый выход фильтра считать равным первому замеру

### DIFF
--- a/src/filters/runningAverage.h
+++ b/src/filters/runningAverage.h
@@ -33,6 +33,7 @@ public:
     }
 
     float filtered(float value) {
+        if (_first) {_fil = value; _first = false;}
         return _fil += (value - _fil) * _coef;
     }
     
@@ -43,6 +44,7 @@ public:
     
 private:
     float _coef = 0.0, _fil = 0.0;
+    bool _first = true;
     uint32_t _tmr = 0;
     uint16_t _prd = 0;
 };


### PR DESCRIPTION
Позволяет сразу использовать фильтр "на полную", а не "подбираться" к измеряемым значениям. При малых значениях коэффициента, этот выход может быть  длительным, а выход фильтра значительно отличаться от входных данных. Подробнее - скриншоты графиков работы. Входная функция: random(100, 105); 
исходный вариант: https://disk.yandex.ru/i/8ITsw26YZcQ9ng 
модификация: https://disk.yandex.ru/i/-Mw9TFuYz3ytSQ

